### PR TITLE
Add startup time tests for various publish options

### DIFF
--- a/TrimmedTodo.sln
+++ b/TrimmedTodo.sln
@@ -24,11 +24,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TrimmedTodo.Worker", "src\T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TrimmedTodo.Console.ApiClient", "src\TrimmedTodo.Console.ApiClient\TrimmedTodo.Console.ApiClient.csproj", "{2B6AA1B0-BD6B-415F-9F82-0C28C9A89465}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorld.Console", "src\HelloWorld.Console\HelloWorld.Console.csproj", "{B59EAF71-EC94-4466-9F78-51DC3C63D757}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HelloWorld.Console", "src\HelloWorld.Console\HelloWorld.Console.csproj", "{B59EAF71-EC94-4466-9F78-51DC3C63D757}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorld.Web", "src\HelloWorld.Web\HelloWorld.Web.csproj", "{98EDBC8B-3120-4BF4-A253-B23D9ECB2C76}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HelloWorld.Web", "src\HelloWorld.Web\HelloWorld.Web.csproj", "{98EDBC8B-3120-4BF4-A253-B23D9ECB2C76}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrimmedTodo.MinimalApi.Dapper.Sqlite", "src\TrimmedTodo.MinimalApi.Dapper.Sqlite\TrimmedTodo.MinimalApi.Dapper.Sqlite.csproj", "{7DA5CA1C-14FD-48AA-AB69-387786707535}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TrimmedTodo.MinimalApi.Dapper.Sqlite", "src\TrimmedTodo.MinimalApi.Dapper.Sqlite\TrimmedTodo.MinimalApi.Dapper.Sqlite.csproj", "{7DA5CA1C-14FD-48AA-AB69-387786707535}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{208008E4-35D7-43F6-8574-696AB9CC76A6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks", "tests\Benchmarks\Benchmarks.csproj", "{234710A4-FE63-4E7E-8604-DF6AB9BA2657}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -72,6 +76,10 @@ Global
 		{7DA5CA1C-14FD-48AA-AB69-387786707535}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7DA5CA1C-14FD-48AA-AB69-387786707535}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7DA5CA1C-14FD-48AA-AB69-387786707535}.Release|Any CPU.Build.0 = Release|Any CPU
+		{234710A4-FE63-4E7E-8604-DF6AB9BA2657}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{234710A4-FE63-4E7E-8604-DF6AB9BA2657}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{234710A4-FE63-4E7E-8604-DF6AB9BA2657}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{234710A4-FE63-4E7E-8604-DF6AB9BA2657}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -86,6 +94,7 @@ Global
 		{B59EAF71-EC94-4466-9F78-51DC3C63D757} = {42D7C3C4-1A33-430D-9694-E37AD0044933}
 		{98EDBC8B-3120-4BF4-A253-B23D9ECB2C76} = {42D7C3C4-1A33-430D-9694-E37AD0044933}
 		{7DA5CA1C-14FD-48AA-AB69-387786707535} = {42D7C3C4-1A33-430D-9694-E37AD0044933}
+		{234710A4-FE63-4E7E-8604-DF6AB9BA2657} = {208008E4-35D7-43F6-8574-696AB9CC76A6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CCCB8893-DE28-4FD3-BE73-91FE054A9D2A}

--- a/src/HelloWorld.Web/Program.cs
+++ b/src/HelloWorld.Web/Program.cs
@@ -1,3 +1,6 @@
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
@@ -11,5 +14,16 @@ if (builder.Configuration["SHUTDOWN_ON_START"] != "true")
 }
 else
 {
+    var server = app.Services.GetRequiredService<IServer>();
+    var addresses = server.Features.Get<IServerAddressesFeature>();
+    var url = addresses?.Addresses.FirstOrDefault();
+
+    if (url is not null)
+    {
+        using var http = new HttpClient();
+        var response = await http.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+    }
+
     await app.StopAsync();
 }

--- a/src/HelloWorld.Web/Program.cs
+++ b/src/HelloWorld.Web/Program.cs
@@ -3,4 +3,13 @@ var app = builder.Build();
 
 app.MapGet("/", () => "Hello World!");
 
-app.Run();
+await app.StartAsync();
+
+if (builder.Configuration["SHUTDOWN_ON_START"] != "true")
+{
+    app.WaitForShutdown();
+}
+else
+{
+    await app.StopAsync();
+}

--- a/src/HelloWorld.Web/Program.cs
+++ b/src/HelloWorld.Web/Program.cs
@@ -1,29 +1,6 @@
-using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.Hosting.Server.Features;
-
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
 app.MapGet("/", () => "Hello World!");
 
-await app.StartAsync();
-
-if (builder.Configuration["SHUTDOWN_ON_START"] != "true")
-{
-    app.WaitForShutdown();
-}
-else
-{
-    var server = app.Services.GetRequiredService<IServer>();
-    var addresses = server.Features.Get<IServerAddressesFeature>();
-    var url = addresses?.Addresses.FirstOrDefault();
-
-    if (url is not null)
-    {
-        using var http = new HttpClient();
-        var response = await http.GetAsync(url);
-        response.EnsureSuccessStatusCode();
-    }
-
-    await app.StopAsync();
-}
+await app.StartApp();

--- a/src/HelloWorld.Web/WebApplicationExtensions.cs
+++ b/src/HelloWorld.Web/WebApplicationExtensions.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Hosting.Server;
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static partial class WebApplicationExtensions
+{
+    /// <summary>
+    /// Starts the application with awareness of configuration values used by benchmarks & scripts to control the startup behavior.
+    /// </summary>
+    /// <param name="app"></param>
+    /// <returns></returns>
+    public static async Task StartApp(this WebApplication app, PathString firstRequestPath = default)
+    {
+        await app.StartAsync();
+
+        if (app.Configuration["SHUTDOWN_ON_START"] != "true")
+        {
+            app.WaitForShutdown();
+        }
+        else
+        {
+            if (app.Configuration["SUPPRESS_FIRST_REQUEST"] != "true")
+            {
+                var server = app.Services.GetRequiredService<IServer>();
+                var addresses = server.Features.Get<IServerAddressesFeature>();
+                var url = addresses?.Addresses.FirstOrDefault();
+
+                if (url is not null)
+                {
+                    using var http = new HttpClient();
+                    var response = await http.GetAsync(url + firstRequestPath);
+
+                    response.EnsureSuccessStatusCode();
+                }
+            }
+
+            await app.StopAsync();
+        }
+    }
+}

--- a/src/HelloWorld.Web/WebApplicationExtensions.cs
+++ b/src/HelloWorld.Web/WebApplicationExtensions.cs
@@ -16,7 +16,7 @@ public static partial class WebApplicationExtensions
 
         if (app.Configuration["SHUTDOWN_ON_START"] != "true")
         {
-            app.WaitForShutdown();
+            await app.WaitForShutdownAsync();
         }
         else
         {

--- a/src/TrimmedTodo.MinimalApi.Dapper.Sqlite/JwtConfigHelper.cs
+++ b/src/TrimmedTodo.MinimalApi.Dapper.Sqlite/JwtConfigHelper.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static class JwtConfigHelper
+{
+    public static Action<JwtBearerOptions> ConfigureJwtBearer(WebApplicationBuilder builder)
+    {
+        return o =>
+        {
+            if (!builder.Environment.IsDevelopment())
+            {
+                // When not running in development configure the JWT signing key from environment variable
+                var jwtKeyMaterialValue = builder.Configuration["JWT_SIGNING_KEY"];
+
+                if (string.IsNullOrEmpty(jwtKeyMaterialValue))
+                    throw new InvalidOperationException("JWT signing key not found!");
+
+                var jwtKeyMaterial = Convert.FromBase64String(jwtKeyMaterialValue);
+                var jwtSigningKey = new SymmetricSecurityKey(jwtKeyMaterial);
+                o.TokenValidationParameters.IssuerSigningKey = jwtSigningKey;
+            }
+        };
+    }
+
+    public static bool ValidateJwtOptions(JwtBearerOptions options, IHostEnvironment hostEnvironment, ILoggerFactory loggerFactory)
+    {
+        var relevantOptions = new JwtOptionsSummary
+        {
+            Audience = options.Audience,
+            ClaimsIssuer = options.ClaimsIssuer,
+            Audiences = options.TokenValidationParameters?.ValidAudiences,
+            Issuers = options.TokenValidationParameters?.ValidIssuers,
+            IssuerSigningKey = options.TokenValidationParameters?.IssuerSigningKey,
+            IssuerSigningKeys = options.TokenValidationParameters?.IssuerSigningKeys
+        };
+
+        var logger = loggerFactory.CreateLogger(hostEnvironment.ApplicationName ?? nameof(Program));
+        logger.LogInformation("JwtBearerAuthentication options configuration: {JwtOptions}",
+            JsonSerializer.Serialize(relevantOptions, ProgramJsonSerializerContext.Default.JwtOptionsSummary));
+
+        if ((string.IsNullOrEmpty(relevantOptions.Audience) && relevantOptions.Audiences?.Any() != true)
+            || (relevantOptions.ClaimsIssuer is null && relevantOptions.Issuers?.Any() != true)
+            || (relevantOptions.IssuerSigningKey is null && relevantOptions.IssuerSigningKeys?.Any() != true))
+        {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+
+internal class JwtOptionsSummary
+{
+    public string? Audience { get; set; }
+    public string? ClaimsIssuer { get; set; }
+    public IEnumerable<string>? Audiences { get; set; }
+    public IEnumerable<string>? Issuers { get; set; }
+    public SecurityKey? IssuerSigningKey { get; set; }
+    public IEnumerable<SecurityKey>? IssuerSigningKeys { get; set; }
+}
+
+[JsonSerializable(typeof(JwtOptionsSummary))]
+internal partial class ProgramJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/TrimmedTodo.MinimalApi.Dapper.Sqlite/Program.cs
+++ b/src/TrimmedTodo.MinimalApi.Dapper.Sqlite/Program.cs
@@ -61,7 +61,16 @@ app.UseSwaggerUI();
 
 app.MapTodoApi();
 
-app.Run();
+await app.StartAsync();
+
+if (builder.Configuration["SHUTDOWN_ON_START"] != "true")
+{
+    app.WaitForShutdown();
+}
+else
+{
+    await app.StopAsync();
+}
 
 async Task EnsureDb(IServiceProvider services, ILogger logger)
 {

--- a/src/TrimmedTodo.MinimalApi.Dapper.Sqlite/Program.cs
+++ b/src/TrimmedTodo.MinimalApi.Dapper.Sqlite/Program.cs
@@ -1,10 +1,7 @@
 using System.Data;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Dapper;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Data.Sqlite;
-using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,26 +11,12 @@ if (!builder.Environment.IsDevelopment())
 }
 
 builder.Services.AddAuthentication()
-    .AddJwtBearer(o =>
-    {
-        if (!builder.Environment.IsDevelopment())
-        {
-            // When not running in development configure the JWT signing key from environment variable
-            var jwtKeyMaterialValue = builder.Configuration["JWT_SIGNING_KEY"];
-
-            if (string.IsNullOrEmpty(jwtKeyMaterialValue))
-                throw new InvalidOperationException("JWT signing key not found!");
-
-            var jwtKeyMaterial = Convert.FromBase64String(jwtKeyMaterialValue);
-            var jwtSigningKey = new SymmetricSecurityKey(jwtKeyMaterial);
-            o.TokenValidationParameters.IssuerSigningKey = jwtSigningKey;
-        }
-    });
+    .AddJwtBearer(JwtConfigHelper.ConfigureJwtBearer(builder));
 
 builder.Services.AddAuthorization();
 
 builder.Services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
-    .Validate<IHostEnvironment, ILoggerFactory>(ValidateJwtOptions,
+    .Validate<IHostEnvironment, ILoggerFactory>(JwtConfigHelper.ValidateJwtOptions,
         "JWT options are not configured. Run 'dotnet user-jwts create' in project directory to configure JWT.")
     .ValidateOnStart();
 
@@ -61,16 +44,7 @@ app.UseSwaggerUI();
 
 app.MapTodoApi();
 
-await app.StartAsync();
-
-if (builder.Configuration["SHUTDOWN_ON_START"] != "true")
-{
-    app.WaitForShutdown();
-}
-else
-{
-    await app.StopAsync();
-}
+await app.StartApp("/api/todos");
 
 async Task EnsureDb(IServiceProvider services, ILogger logger)
 {
@@ -85,40 +59,4 @@ async Task EnsureDb(IServiceProvider services, ILogger logger)
                   );
                """;
     await db.ExecuteAsync(sql);
-}
-
-static bool ValidateJwtOptions(JwtBearerOptions options, IHostEnvironment hostEnvironment, ILoggerFactory loggerFactory)
-{
-    var relevantOptions = new JwtOptionsSummary
-    {
-        Audience = options.Audience,
-        ClaimsIssuer = options.ClaimsIssuer,
-        Audiences = options.TokenValidationParameters?.ValidAudiences,
-        Issuers = options.TokenValidationParameters?.ValidIssuers,
-        IssuerSigningKey = options.TokenValidationParameters?.IssuerSigningKey.ToString()
-    };
-    if ((string.IsNullOrEmpty(relevantOptions.Audience) && relevantOptions.Audiences?.Any() != true)
-        || (relevantOptions.ClaimsIssuer is null && relevantOptions.Issuers?.Any() != true)
-        || string.IsNullOrEmpty(relevantOptions.IssuerSigningKey))
-    {
-        return false;
-    }
-    var logger = loggerFactory.CreateLogger(hostEnvironment.ApplicationName ?? nameof(Program));
-    logger.LogInformation("JwtBearerAuthentication options configuration: {JwtOptions}",
-        JsonSerializer.Serialize(relevantOptions, ProgramJsonSerializerContext.Default.JwtOptionsSummary));
-    return true;
-}
-
-internal class JwtOptionsSummary
-{
-    public string? Audience { get; set; }
-    public string? ClaimsIssuer { get; set; }
-    public IEnumerable<string>? Audiences { get; set; }
-    public IEnumerable<string>? Issuers { get; set; }
-    public string? IssuerSigningKey { get; set; }
-}
-
-[JsonSerializable(typeof(JwtOptionsSummary))]
-internal partial class ProgramJsonSerializerContext : JsonSerializerContext
-{
 }

--- a/src/TrimmedTodo.MinimalApi.Dapper.Sqlite/TrimmedTodo.MinimalApi.Dapper.Sqlite.csproj
+++ b/src/TrimmedTodo.MinimalApi.Dapper.Sqlite/TrimmedTodo.MinimalApi.Dapper.Sqlite.csproj
@@ -15,10 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="JwtConfigHelper.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <!-- Manually marking these assemblies as trimmable until we update them -->
     <TrimmableAssembly Include="Microsoft.IdentityModel.Tokens" />
     <TrimmableAssembly Include="Microsoft.AspNetCore.Components.Server" />

--- a/src/TrimmedTodo.MinimalApi.Dapper.Sqlite/TrimmedTodo.MinimalApi.Dapper.Sqlite.csproj
+++ b/src/TrimmedTodo.MinimalApi.Dapper.Sqlite/TrimmedTodo.MinimalApi.Dapper.Sqlite.csproj
@@ -11,6 +11,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\HelloWorld.Web\WebApplicationExtensions.cs" Link="WebApplicationExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="JwtConfigHelper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Manually marking these assemblies as trimmable until we update them -->
     <TrimmableAssembly Include="Microsoft.IdentityModel.Tokens" />
     <TrimmableAssembly Include="Microsoft.AspNetCore.Components.Server" />

--- a/src/TrimmedTodo.MinimalApi.EfCore.Sqlite/Program.cs
+++ b/src/TrimmedTodo.MinimalApi.EfCore.Sqlite/Program.cs
@@ -59,7 +59,16 @@ app.UseSwaggerUI();
 
 app.MapTodoApi();
 
-app.Run();
+await app.StartAsync();
+
+if (builder.Configuration["SHUTDOWN_ON_START"] != "true")
+{
+    app.WaitForShutdown();
+}
+else
+{
+    await app.StopAsync();
+}
 
 static bool ValidateJwtOptions(JwtBearerOptions options, IHostEnvironment hostEnvironment, ILoggerFactory loggerFactory)
 {

--- a/src/TrimmedTodo.MinimalApi.EfCore.Sqlite/TrimmedTodo.MinimalApi.EfCore.Sqlite.csproj
+++ b/src/TrimmedTodo.MinimalApi.EfCore.Sqlite/TrimmedTodo.MinimalApi.EfCore.Sqlite.csproj
@@ -11,6 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\HelloWorld.Web\WebApplicationExtensions.cs" Link="WebApplicationExtensions.cs" />
+    <Compile Include="..\TrimmedTodo.MinimalApi.Dapper.Sqlite\JwtConfigHelper.cs" Link="JwtConfigHelper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Manually marking these assemblies as trimmable until we update them -->
     <TrimmableAssembly Include="Microsoft.IdentityModel.Tokens" />
     <TrimmableAssembly Include="Microsoft.AspNetCore.Components.Server" />

--- a/src/TrimmedTodo.WebApi.EfCore.Sqlite/Program.cs
+++ b/src/TrimmedTodo.WebApi.EfCore.Sqlite/Program.cs
@@ -1,8 +1,5 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.IdentityModel.Tokens;
 using TrimmedTodo.WebApi.EfCore.Sqlite.Data;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -13,26 +10,12 @@ if (!builder.Environment.IsDevelopment())
 }
 
 builder.Services.AddAuthentication()
-    .AddJwtBearer(o =>
-    {
-        if (!builder.Environment.IsDevelopment())
-        {
-            // When not running in development configure the JWT signing key from environment variable
-            var jwtKeyMaterialValue = builder.Configuration["JWT_SIGNING_KEY"];
-
-            if (string.IsNullOrEmpty(jwtKeyMaterialValue))
-                throw new InvalidOperationException("JWT signing key not found!");
-
-            var jwtKeyMaterial = Convert.FromBase64String(jwtKeyMaterialValue);
-            var jwtSigningKey = new SymmetricSecurityKey(jwtKeyMaterial);
-            o.TokenValidationParameters.IssuerSigningKey = jwtSigningKey;
-        }
-    });
+    .AddJwtBearer(JwtConfigHelper.ConfigureJwtBearer(builder));
 
 builder.Services.AddAuthorization();
 
 builder.Services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
-    .Validate<IHostEnvironment, ILoggerFactory>(ValidateJwtOptions,
+    .Validate<IHostEnvironment, ILoggerFactory>(JwtConfigHelper.ValidateJwtOptions,
         "JWT options are not configured. Run 'dotnet user-jwts create' in project directory to configure JWT.")
     .ValidateOnStart();
 
@@ -55,38 +38,7 @@ app.UseSwaggerUI();
 
 app.MapControllers();
 
-await app.StartAsync();
-
-if (builder.Configuration["SHUTDOWN_ON_START"] != "true")
-{
-    app.WaitForShutdown();
-}
-else
-{
-    await app.StopAsync();
-}
-
-static bool ValidateJwtOptions(JwtBearerOptions options, IHostEnvironment hostEnvironment, ILoggerFactory loggerFactory)
-{
-    var relevantOptions = new JwtOptionsSummary
-    {
-        Audience = options.Audience,
-        ClaimsIssuer = options.ClaimsIssuer,
-        Audiences = options.TokenValidationParameters?.ValidAudiences,
-        Issuers = options.TokenValidationParameters?.ValidIssuers,
-        IssuerSigningKey = options.TokenValidationParameters?.IssuerSigningKey?.ToString()
-    };
-    if ((string.IsNullOrEmpty(relevantOptions.Audience) && relevantOptions.Audiences?.Any() != true)
-        || (relevantOptions.ClaimsIssuer is null && relevantOptions.Issuers?.Any() != true)
-        || string.IsNullOrEmpty(relevantOptions.IssuerSigningKey))
-    {
-        return false;
-    }
-    var logger = loggerFactory.CreateLogger(hostEnvironment.ApplicationName ?? nameof(Program));
-    logger.LogInformation("JwtBearerAuthentication options configuration: {JwtOptions}",
-        JsonSerializer.Serialize(relevantOptions, ProgramJsonSerializerContext.Default.JwtOptionsSummary));
-    return true;
-}
+await app.StartApp("/api/todos");
 
 static async Task EnsureDb(string cs, IServiceProvider services, ILogger logger)
 {
@@ -94,18 +46,4 @@ static async Task EnsureDb(string cs, IServiceProvider services, ILogger logger)
 
     using var db = services.CreateScope().ServiceProvider.GetRequiredService<TodoDb>();
     await db.Database.MigrateAsync();
-}
-
-internal class JwtOptionsSummary
-{
-    public string? Audience { get; set; }
-    public string? ClaimsIssuer { get; set; }
-    public IEnumerable<string>? Audiences { get; set; }
-    public IEnumerable<string>? Issuers { get; set; }
-    public string? IssuerSigningKey { get; set; }
-}
-
-[JsonSerializable(typeof(JwtOptionsSummary))]
-internal partial class ProgramJsonSerializerContext : JsonSerializerContext
-{
 }

--- a/src/TrimmedTodo.WebApi.EfCore.Sqlite/Program.cs
+++ b/src/TrimmedTodo.WebApi.EfCore.Sqlite/Program.cs
@@ -55,7 +55,16 @@ app.UseSwaggerUI();
 
 app.MapControllers();
 
-app.Run();
+await app.StartAsync();
+
+if (builder.Configuration["SHUTDOWN_ON_START"] != "true")
+{
+    app.WaitForShutdown();
+}
+else
+{
+    await app.StopAsync();
+}
 
 static bool ValidateJwtOptions(JwtBearerOptions options, IHostEnvironment hostEnvironment, ILoggerFactory loggerFactory)
 {

--- a/src/TrimmedTodo.WebApi.EfCore.Sqlite/TrimmedTodo.WebApi.EfCore.Sqlite.csproj
+++ b/src/TrimmedTodo.WebApi.EfCore.Sqlite/TrimmedTodo.WebApi.EfCore.Sqlite.csproj
@@ -11,6 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\HelloWorld.Web\WebApplicationExtensions.cs" Link="WebApplicationExtensions.cs" />
+    <Compile Include="..\TrimmedTodo.MinimalApi.Dapper.Sqlite\JwtConfigHelper.cs" Link="JwtConfigHelper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0-rc.1.*" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0-rc.1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.0-rc.1.*" />

--- a/tests/Benchmarks/AppRunner.cs
+++ b/tests/Benchmarks/AppRunner.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Benchmarks;
+
+class AppRunner
+{
+    private static readonly string _dotnetFileName = "dotnet" + (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "");
+
+    public static void Run(string appExePath, params (string, string)[] envVars)
+    {
+        if (!File.Exists(appExePath))
+        {
+            throw new ArgumentException($"Could not find application exe '{appExePath}'", nameof(appExePath));
+        }
+
+        var isAppHost = !Path.GetExtension(appExePath)!.Equals(".dll", StringComparison.OrdinalIgnoreCase);
+
+        var process = new Process
+        {
+            StartInfo =
+            {
+                FileName = isAppHost ? appExePath : _dotnetFileName,
+                UseShellExecute = false,
+                WorkingDirectory = Path.GetDirectoryName(appExePath),
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            }
+        };
+
+        if (!isAppHost)
+        {
+            process.StartInfo.ArgumentList.Add(appExePath);
+        }
+
+        foreach (var (name, value) in envVars)
+        {
+            process.StartInfo.Environment.Add(name, value);
+        }
+
+        if (!process.Start())
+        {
+            HandleError(process, "Failed to start application process");
+        }
+
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            HandleError(process, $"Application process failed on exit ({process.ExitCode})");
+        }
+
+        static void HandleError(Process process, string message)
+        {
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+
+            var sb = new StringBuilder();
+            sb.AppendLine(message);
+            sb.AppendLine("Standard output:");
+            sb.AppendLine(output);
+            sb.AppendLine("Standard error:");
+            sb.AppendLine(error);
+
+            throw new InvalidOperationException(sb.ToString());
+        }
+    }
+}

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Benchmarks/DotNetCli.cs
+++ b/tests/Benchmarks/DotNetCli.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Benchmarks;
+class DotNetCli
+{
+    private static readonly string _fileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    public static void Clean(IEnumerable<string> args)
+    {
+        RunCommand("clean", args);
+    }
+
+    public static void Publish(IEnumerable<string> args)
+    {
+        RunCommand("publish", args);
+    }
+
+    private static void RunCommand(string commandName, IEnumerable<string> args)
+    {
+        var process = new Process
+        {
+            StartInfo =
+            {
+                FileName = _fileName,
+                UseShellExecute = false
+            }
+        };
+
+        process.StartInfo.ArgumentList.Add(commandName);
+        foreach (var arg in args)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
+
+        var cmdLine = $"{process.StartInfo.FileName} {string.Join(' ', process.StartInfo.ArgumentList)}";
+        Console.WriteLine("Running dotnet CLI with cmd line:");
+        Console.WriteLine(cmdLine);
+        Console.WriteLine();
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException($"dotnet {commandName} failed");
+        }
+
+        process.WaitForExit();
+
+        if (!process.WaitForExit(_timeout))
+        {
+            process.Kill();
+
+            throw new InvalidOperationException($"dotnet {commandName} took longer than the allowed time of {_timeout}");
+        }
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"dotnet {commandName} failed on exit ({process.ExitCode})");
+        }
+    }
+}

--- a/tests/Benchmarks/GroupByProjectNameOrderer.cs
+++ b/tests/Benchmarks/GroupByProjectNameOrderer.cs
@@ -1,0 +1,33 @@
+using System.Collections.Immutable;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Order;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+
+namespace Benchmarks;
+public class GroupByProjectNameOrderer : DefaultOrderer, IOrderer
+{
+    public override IEnumerable<BenchmarkCase> GetSummaryOrder(ImmutableArray<BenchmarkCase> benchmarksCases, Summary summary)
+    {
+        var benchmarkLogicalGroups = benchmarksCases.GroupBy(b => GetLogicalGroupKeyImpl(b));
+
+        foreach (var logicalGroup in GetLogicalGroupOrder(benchmarkLogicalGroups, benchmarksCases.FirstOrDefault()?.Config.GetLogicalGroupRules()))
+        foreach (var benchmark in GetSummaryOrderForGroup(logicalGroup.ToImmutableArray(), summary))
+            yield return benchmark;
+    }
+
+    public override IEnumerable<IGrouping<string, BenchmarkCase>> GetLogicalGroupOrder(IEnumerable<IGrouping<string, BenchmarkCase>> logicalGroups, IEnumerable<BenchmarkLogicalGroupRule>? order = null)
+    {
+        var initialOrder = base.GetLogicalGroupOrder(logicalGroups, order);
+
+        var cases = initialOrder.SelectMany(g => g.ToList());
+        var newOrder = cases.GroupBy(c => c.Parameters[nameof(StartupTimeBenchmarks.ProjectName)].ToString() ?? "").ToList();
+        return newOrder;
+    }
+
+    string IOrderer.GetLogicalGroupKey(ImmutableArray<BenchmarkCase> allBenchmarksCases, BenchmarkCase benchmarkCase)
+        => GetLogicalGroupKeyImpl(benchmarkCase);
+
+    private static string GetLogicalGroupKeyImpl(BenchmarkCase benchmarkCase)
+        => benchmarkCase.Parameters[nameof(StartupTimeBenchmarks.ProjectName)].ToString() ?? "";
+}

--- a/tests/Benchmarks/PathHelper.cs
+++ b/tests/Benchmarks/PathHelper.cs
@@ -1,0 +1,35 @@
+namespace Benchmarks;
+
+class PathHelper
+{
+    public static string RepoRoot { get; } = GetRepoRoot();
+    public static string ProjectsDir { get; } = Path.Combine(RepoRoot, "src");
+    public static string ArtifactsDir { get; } = Path.Combine(RepoRoot, ".artifacts");
+    public static string BenchmarkArtifactsDir { get; } = Path.Combine(ArtifactsDir, "benchmarks");
+
+    private static string GetRepoRoot()
+    {
+        var currentDir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        DirectoryInfo? repoDir = null;
+
+        while (true)
+        {
+            if (currentDir is null)
+            {
+                // We hit the file system root
+                break;
+            }
+
+            if (File.Exists(Path.Join(currentDir.FullName, "TrimmedTodo.sln")))
+            {
+                // We're in the repo root
+                repoDir = currentDir;
+                break;
+            }
+
+            currentDir = currentDir.Parent;
+        }
+
+        return repoDir is null ? throw new InvalidOperationException("Couldn't find repo directory") : repoDir.FullName;
+    }
+}

--- a/tests/Benchmarks/Program.cs
+++ b/tests/Benchmarks/Program.cs
@@ -5,6 +5,7 @@ using System.Text;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
@@ -31,21 +32,21 @@ else
         );
 }
 
-[SimpleJob(launchCount: 1, warmupCount: 1, targetCount: 3, invocationCount: 6)]
+[SimpleJob(RunStrategy.ColdStart, launchCount: 1, warmupCount: 1, invocationCount: 1, targetCount: 10)]
 public class StartupTimeBenchmarks
 {
     private string? _appPath;
 
     //[Params("HelloWorld.Console")]
-    //[Params("HelloWorld.Web")]
+    [Params("HelloWorld.Web")]
     //[Params("HelloWorld.Console", "HelloWorld.Web")]
-    [Params("HelloWorld.Console", "HelloWorld.Web", "TrimmedTodo.Console.EfCore.Sqlite")]
+    //[Params("HelloWorld.Console", "HelloWorld.Web", "TrimmedTodo.Console.EfCore.Sqlite")]
     //[Params("TrimmedTodo.Console.EfCore.Sqlite")]
     public string ProjectName { get; set; } = default!;
 
     //[ParamsAllValues]
     //[Params(PublishScenario.Default, PublishScenario.Trimmed)]
-    [Params(PublishScenario.Default, PublishScenario.Trimmed, PublishScenario.TrimmedReadyToRun)]
+    [Params(PublishScenario.Default, PublishScenario.Trimmed, PublishScenario.TrimmedReadyToRun, PublishScenario.AOT)]
     //[Params(PublishScenario.SingleFileReadyToRun)]
     //[Params(PublishScenario.Default, PublishScenario.NoAppHost, PublishScenario.ReadyToRun, PublishScenario.SelfContained, PublishScenario.SelfContainedReadyToRun,
     //    PublishScenario.SingleFile, PublishScenario.SingleFileReadyToRun, PublishScenario.Trimmed, PublishScenario.TrimmedReadyToRun)]

--- a/tests/Benchmarks/Program.cs
+++ b/tests/Benchmarks/Program.cs
@@ -1,0 +1,311 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
+
+// Clean up previous run
+
+
+BenchmarkRunner.Run<HelloWorldWebStartupTimeBenchmarks>();
+//BenchmarkRunner.Run<HelloWorldWebStartupTimeBenchmarks>(new DebugInProcessConfig());
+
+[SimpleJob(launchCount: 1, warmupCount: 2, targetCount: 10)]
+public class HelloWorldWebStartupTimeBenchmarks
+{
+    private readonly string _projectName = "HelloWorld.Web";
+    private string? _appPath;
+
+    [GlobalSetup(Target = nameof(Default))]
+    public void PublishDefault()
+    {
+        _appPath = ProjectBuilder.Publish(_projectName);
+    }
+
+    [Benchmark]
+    public void Default()
+    {
+        AppRunner.Run(_appPath!, ("SHUTDOWN_ON_START", "true"));
+    }
+
+    [GlobalSetup(Target = nameof(SelfContained))]
+    public void PublishSelfContained()
+    {
+        _appPath = ProjectBuilder.Publish(_projectName, selfContained: true, trimLevel: TrimLevel.Default);
+    }
+
+    [Benchmark]
+    public void SelfContained()
+    {
+        AppRunner.Run(_appPath!, ("SHUTDOWN_ON_START", "true"));
+    }
+
+    [GlobalSetup(Target = nameof(Trimmed))]
+    public void PublishTrimmed()
+    {
+        _appPath = ProjectBuilder.Publish(_projectName, trimLevel: TrimLevel.Default);
+    }
+
+    [Benchmark]
+    public void Trimmed()
+    {
+        AppRunner.Run(_appPath!, ("SHUTDOWN_ON_START", "true"));
+    }
+
+    [GlobalSetup(Target = nameof(AOT))]
+    public void PublishAOT()
+    {
+        _appPath = ProjectBuilder.PublishAot(_projectName);
+    }
+
+    [Benchmark]
+    public void AOT()
+    {
+        AppRunner.Run(_appPath!, ("SHUTDOWN_ON_START", "true"));
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        var appDir = Path.GetDirectoryName(_appPath);
+        if (Directory.Exists(appDir))
+        {
+            Directory.Delete(appDir, true);
+        }
+    }
+}
+
+class ProjectBuilder
+{
+    private static readonly string _repoDirPath = PathHelper.GetRepoRoot();
+    private static readonly string _projectsDirPath = Path.Combine(_repoDirPath, "src");
+    private static readonly string _artifactsDirPath = Path.Combine(_repoDirPath, ".artifacts", "benchmarks");
+
+    public static string Publish(
+        string projectName,
+        string configuration = "Release",
+        string? output = null,
+        bool selfContained = false,
+        bool singleFile = false,
+        TrimLevel trimLevel = TrimLevel.None)
+    {
+        var args = new List<string>
+        {
+            "--configuration", configuration,
+            "--self-contained", trimLevel != TrimLevel.None ? "true" : selfContained.ToString().ToLowerInvariant(),
+            "--runtime", RuntimeInformation.RuntimeIdentifier,
+            $"/p:PublishTrimmed={(trimLevel == TrimLevel.None ? "false" : "true")}",
+            $"/p:PublishSingleFile={singleFile.ToString().ToLowerInvariant()}",
+            "/p:PublishAot=false"
+        };
+
+        if (trimLevel != TrimLevel.None)
+        {
+            args.Add(GetTrimLevelProperty(trimLevel));
+        }
+
+        return Publish(projectName, output, args);
+    }
+
+    public static string PublishAot(
+        string projectName,
+        string configuration = "Release",
+        string? output = null,
+        TrimLevel trimLevel = TrimLevel.Default)
+    {
+        var args = new List<string>
+        {
+            "--configuration", configuration,
+            "--self-contained", "true",
+            "--runtime", RuntimeInformation.RuntimeIdentifier,
+            "/p:PublishAot=true",
+            $"/p:PublishTrimmed={(trimLevel == TrimLevel.None ? "false" : "true")}",
+            "/p:PublishSingleFile=false"
+        };
+
+        if (trimLevel != TrimLevel.None)
+        {
+            args.Add(GetTrimLevelProperty(trimLevel));
+        }
+
+        return Publish(projectName, output, args);
+    }
+
+    private static string Publish(string projectName, string? output = null, IEnumerable<string>? args = null)
+    {
+        var projectPath = Path.Combine(_projectsDirPath, projectName, projectName + ".csproj");
+
+        if (!File.Exists(projectPath))
+        {
+            throw new ArgumentException($"Project at '{projectPath}' could not be found", nameof(projectName));
+        }
+
+        var runId = Random.Shared.NextInt64().ToString();
+        output ??= Path.Combine(_artifactsDirPath, projectName, runId);
+
+        var publishArgs = new List<string>
+        {
+            projectPath,
+            "--output", output
+        };
+        if (args is not null)
+        {
+            publishArgs.AddRange(args);
+        }
+
+        //Directory.Delete(output, true);
+
+        DotNetCli.Publish(publishArgs);
+
+        var appExePath = Path.Join(output, projectName);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            appExePath += ".exe";
+        }
+
+        if (!File.Exists(appExePath))
+        {
+            throw new InvalidOperationException("Could not find application exe");
+        }
+
+        return appExePath;
+    }
+
+    private static string GetTrimLevelProperty(TrimLevel trimLevel)
+    {
+        return "/p:TrimMode=" + trimLevel switch
+        {
+            TrimLevel.Default => "",
+            _ => Enum.GetName(trimLevel)?.ToLower() ?? ""
+        };
+    }
+}
+
+class AppRunner
+{
+    private static readonly string _dotnetFileName = "dotnet" + (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "");
+
+    public static void Run(string appExePath, params (string Name, string Value)[] envVars)
+    {
+        if (!File.Exists(appExePath))
+        {
+            throw new ArgumentException("Could not find application exe", nameof(appExePath));
+        }
+
+        var isAppHost = !Path.GetExtension(appExePath)!.Equals(".dll", StringComparison.OrdinalIgnoreCase);
+
+        var process = new Process
+        {
+            StartInfo =
+            {
+                FileName = isAppHost ? appExePath : _dotnetFileName,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            }
+        };
+
+        if (!isAppHost)
+        {
+            process.StartInfo.ArgumentList.Add(appExePath);
+        }
+
+        foreach (var envVar in envVars)
+        {
+            process.StartInfo.Environment.Add(envVar.Name, envVar.Value);
+        }
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Failed to start application process");
+        }
+
+        process.WaitForExit();
+    }
+}
+
+
+class DotNetCli
+{
+    private static readonly string _fileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    public static void Publish(IEnumerable<string> args)
+    {
+        var process = new Process
+        {
+            StartInfo =
+            {
+                FileName = _fileName,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            }
+        };
+
+        process.StartInfo.ArgumentList.Add("publish");
+        foreach (var arg in args)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("dotnet publish failed");
+        }
+
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+
+        var _ = process.WaitForExit(_timeout);
+    }
+}
+
+class PathHelper
+{
+    private static readonly string _repoDirPath = GetRepoRoot();
+    private static readonly string _projectsDirPath = Path.Combine(_repoDirPath, "src");
+    private static readonly string _artifactsDirPath = Path.Combine(_repoDirPath, ".artifacts", "benchmarks");
+
+    public static string GetRepoRoot()
+    {
+        var currentDirPath = Environment.CurrentDirectory;
+        DirectoryInfo? repoDir = null;
+        while (true)
+        {
+            var parent = Directory.GetParent(currentDirPath);
+
+            if (parent is null)
+            {
+                // We hit the root
+                break;
+            }
+
+            if (File.Exists(Path.Join(parent.FullName, "TrimmedTodo.sln")))
+            {
+                // We're in the repo root
+                repoDir = parent;
+                break;
+            }
+
+            currentDirPath = parent.FullName;
+        }
+
+        if (repoDir is null)
+        {
+            throw new InvalidOperationException("Couldn't find repo directory");
+        }
+
+        return repoDir.FullName;
+    }
+}
+
+enum TrimLevel
+{
+    None,
+    Default,
+    Partial,
+    Full
+}

--- a/tests/Benchmarks/Program.cs
+++ b/tests/Benchmarks/Program.cs
@@ -1,14 +1,11 @@
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Text;
+using System.Text.Json;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;
-using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
+using Benchmarks;
 
 if (Directory.Exists(PathHelper.BenchmarkArtifactsDir))
 {
@@ -23,7 +20,8 @@ var config = (Debugger.IsAttached ? new DebugInProcessConfig() : DefaultConfig.I
 if (Debugger.IsAttached)
 {
     BenchmarkRunner.Run<StartupTimeBenchmarks>(config
-        .WithOption(ConfigOptions.StopOnFirstError, true));
+        //.WithOption(ConfigOptions.StopOnFirstError, true)
+        );
 }
 else
 {
@@ -35,31 +33,80 @@ else
 [SimpleJob(RunStrategy.ColdStart, launchCount: 1, warmupCount: 1, invocationCount: 1, targetCount: 10)]
 public class StartupTimeBenchmarks
 {
-    private string? _appPath;
+    private string _appPath = default!;
+    private string? _userSecretsId = default;
 
-    //[Params("HelloWorld.Console")]
-    [Params("HelloWorld.Web")]
-    //[Params("HelloWorld.Console", "HelloWorld.Web")]
-    //[Params("HelloWorld.Console", "HelloWorld.Web", "TrimmedTodo.Console.EfCore.Sqlite")]
-    //[Params("TrimmedTodo.Console.EfCore.Sqlite")]
+    public static IEnumerable<string> ProjectNames() => new[]
+    {
+        //"HelloWorld.Console",
+        //"HelloWorld.Web",
+        //"TrimmedTodo.Console.EfCore.Sqlite",
+        "TrimmedTodo.MinimalApi.EfCore.Sqlite",
+        //"TrimmedTodo.MinimalApi.Dapper.Sqlite"
+    };
+
+    public static IEnumerable<PublishScenario> Scenarios() => new[]
+    {
+        PublishScenario.Default,
+        //PublishScenario.NoAppHost,
+        //PublishScenario.ReadyToRun,
+        //PublishScenario.SelfContained,
+        //PublishScenario.SelfContainedReadyToRun,
+        //PublishScenario.SingleFile,
+        PublishScenario.SingleFileReadyToRun,
+        //PublishScenario.Trimmed,
+        //PublishScenario.TrimmedReadyToRun,
+        //PublishScenario.AOT
+    };
+
+    [ParamsSource(nameof(ProjectNames))]
     public string ProjectName { get; set; } = default!;
 
-    //[ParamsAllValues]
-    //[Params(PublishScenario.Default, PublishScenario.Trimmed)]
-    [Params(PublishScenario.Default, PublishScenario.Trimmed, PublishScenario.TrimmedReadyToRun, PublishScenario.AOT)]
-    //[Params(PublishScenario.SingleFileReadyToRun)]
-    //[Params(PublishScenario.Default, PublishScenario.NoAppHost, PublishScenario.ReadyToRun, PublishScenario.SelfContained, PublishScenario.SelfContainedReadyToRun,
-    //    PublishScenario.SingleFile, PublishScenario.SingleFileReadyToRun, PublishScenario.Trimmed, PublishScenario.TrimmedReadyToRun)]
-    //[Params(PublishScenario.Default, PublishScenario.ReadyToRun, PublishScenario.Trimmed, PublishScenario.AOT)]
-    //[Params(PublishScenario.Default, PublishScenario.SingleFile, PublishScenario.ReadyToRun, PublishScenario.Trimmed)]
-    //[Params(PublishScenario.TrimmedReadyToRun)]
+    [ParamsSource(nameof(Scenarios))]
     public PublishScenario Scenario { get; set; }
 
     [GlobalSetup]
-    public void PublishApp() => _appPath = ProjectBuilder.Publish(ProjectName, Scenario);
+    public void PublishApp()
+    {
+        var (appPath, userSecretsId) = ProjectBuilder.Publish(ProjectName, Scenario);
+        _appPath = appPath;
+        _userSecretsId = userSecretsId;
+    }
 
     [Benchmark]
-    public void StartApp() => AppRunner.Run(_appPath!, ("SHUTDOWN_ON_START", "true"));
+    public void StartApp() => AppRunner.Run(_appPath, GetEnvVars());
+
+    private (string, string)[] GetEnvVars()
+    {
+        var result = new List<(string, string)> { ("SHUTDOWN_ON_START", "true") };
+
+        if (_userSecretsId is not null)
+        {
+            // Set env var for JWT signing key
+            var userSecretsJsonPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Microsoft", "UserSecrets", _userSecretsId, "secrets.json");
+
+            if (!File.Exists(userSecretsJsonPath))
+            {
+                throw new InvalidOperationException($"Could not find user secrets json file at path '{userSecretsJsonPath}'. " +
+                    "Project has a UserSecretsId but has not been initialized for JWT authentication." +
+                    "Please run 'dotnet user-jwts create' in the '$projectName' directory.");
+            }
+
+            var userSecretsJson = JsonDocument.Parse(File.OpenRead(userSecretsJsonPath));
+            var configKeyName = "Authentication:Schemes:Bearer:SigningKeys";
+            var jwtSigningKey = userSecretsJson.RootElement.GetProperty(configKeyName).EnumerateArray()
+                .Single(o => o.GetProperty("Issuer").GetString() == "dotnet-user-jwts")
+                .GetProperty("Value").GetString();
+
+            if (jwtSigningKey is not null)
+            {
+                result.Add(("JWT_SIGNING_KEY", jwtSigningKey));
+            }
+        }
+
+        return result.ToArray();
+    }
 }
 
 public enum PublishScenario
@@ -74,411 +121,4 @@ public enum PublishScenario
     Trimmed,
     TrimmedReadyToRun,
     AOT
-}
-
-public class RatioColumn : IColumn
-{
-    public string Id { get; } = "Ratio";
-    public string ColumnName { get; } = "Ratio";
-    public bool AlwaysShow { get; } = false;
-    public ColumnCategory Category { get; } = ColumnCategory.Custom;
-    public int PriorityInCategory { get; } = 0;
-    public bool IsNumeric { get; } = true;
-    public UnitType UnitType { get; } = UnitType.Dimensionless;
-    public string Legend { get; } = "[CurrentScenario]/[Default]";
-
-    public string GetValue(Summary summary, BenchmarkCase benchmarkCase)
-    {
-        var baseline = summary.BenchmarksCases
-            .SingleOrDefault(c =>
-            {
-                var scenario = c.Parameters[nameof(StartupTimeBenchmarks.Scenario)];
-
-                if (scenario is not PublishScenario.Default)
-                {
-                    return false;
-                }
-
-                for (var i = 0; i < benchmarkCase.Parameters.Count; i++)
-                {
-                    var p = benchmarkCase.Parameters[i];
-
-                    // Skip scenario parameter
-                    if (p.Name == nameof(StartupTimeBenchmarks.Scenario)) continue;
-
-                    if (c.Parameters[p.Name] != p.Value)
-                    {
-                        // Parameter doesn't match
-                        return false;
-                    }
-                }
-                return true;
-            });
-
-        if (baseline is not null)
-        {
-            var baselineReport = summary.Reports.First(r => r.BenchmarkCase == baseline);
-            var report = summary.Reports.First(r => r.BenchmarkCase == benchmarkCase);
-
-            return (report.ResultStatistics.Mean / baselineReport.ResultStatistics.Mean).ToString("#.00");
-        }
-
-        return "?";
-    }
-
-    public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style) => GetValue(summary, benchmarkCase);
-
-    public bool IsAvailable(Summary summary) =>
-        summary.BenchmarksCases.Where(c => c.Parameters[nameof(StartupTimeBenchmarks.Scenario)] switch
-        {
-            PublishScenario.Default => true,
-            _ => false
-        }).Any();
-
-    public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
-}
-
-public class GroupByProjectNameOrderer : DefaultOrderer, IOrderer
-{
-    public override IEnumerable<BenchmarkCase> GetSummaryOrder(ImmutableArray<BenchmarkCase> benchmarksCases, Summary summary)
-    {
-        var benchmarkLogicalGroups = benchmarksCases.GroupBy(b => GetLogicalGroupKeyImpl(b));
-
-        foreach (var logicalGroup in GetLogicalGroupOrder(benchmarkLogicalGroups, benchmarksCases.FirstOrDefault()?.Config.GetLogicalGroupRules()))
-        foreach (var benchmark in GetSummaryOrderForGroup(logicalGroup.ToImmutableArray(), summary))
-            yield return benchmark;
-    }
-
-    public override IEnumerable<IGrouping<string, BenchmarkCase>> GetLogicalGroupOrder(IEnumerable<IGrouping<string, BenchmarkCase>> logicalGroups, IEnumerable<BenchmarkLogicalGroupRule>? order = null)
-    {
-        var initialOrder = base.GetLogicalGroupOrder(logicalGroups, order);
-
-        var cases = initialOrder.SelectMany(g => g.ToList());
-        var newOrder = cases.GroupBy(c => c.Parameters[nameof(StartupTimeBenchmarks.ProjectName)].ToString() ?? "").ToList();
-        return newOrder;
-    }
-
-    string IOrderer.GetLogicalGroupKey(ImmutableArray<BenchmarkCase> allBenchmarksCases, BenchmarkCase benchmarkCase)
-        => GetLogicalGroupKeyImpl(benchmarkCase);
-
-    private static string GetLogicalGroupKeyImpl(BenchmarkCase benchmarkCase)
-        => benchmarkCase.Parameters[nameof(StartupTimeBenchmarks.ProjectName)].ToString() ?? "";
-}
-
-class ProjectBuilder
-{
-    public static string Publish(string projectName, PublishScenario scenario) => scenario switch
-    {
-        PublishScenario.Default => Publish(projectName, runId: Enum.GetName(scenario)),
-        PublishScenario.NoAppHost => Publish(projectName, useAppHost: false, runId: Enum.GetName(scenario)),
-        PublishScenario.ReadyToRun => Publish(projectName, readyToRun: true, runId: Enum.GetName(scenario)),
-        PublishScenario.SelfContained => Publish(projectName, selfContained: true, trimLevel: TrimLevel.None, runId: Enum.GetName(scenario)),
-        PublishScenario.SelfContainedReadyToRun => Publish(projectName, selfContained: true, readyToRun: true, trimLevel: TrimLevel.None, runId: Enum.GetName(scenario)),
-        PublishScenario.SingleFile => Publish(projectName, selfContained: true, singleFile: true, trimLevel: TrimLevel.None, runId: Enum.GetName(scenario)),
-        PublishScenario.SingleFileReadyToRun => Publish(projectName, selfContained: true, singleFile: true, readyToRun: true, trimLevel: TrimLevel.None, runId: Enum.GetName(scenario)),
-        PublishScenario.Trimmed => Publish(projectName, selfContained: true, singleFile: true, trimLevel: GetTrimLevel(projectName), runId: Enum.GetName(scenario)),
-        PublishScenario.TrimmedReadyToRun => Publish(projectName, selfContained: true, singleFile: true, readyToRun: true, trimLevel: GetTrimLevel(projectName), runId: Enum.GetName(scenario)),
-        PublishScenario.AOT => PublishAot(projectName, trimLevel: GetTrimLevel(projectName), runId: Enum.GetName(scenario)),
-        _ => throw new ArgumentException("Unrecognized publish scenario", nameof(scenario))
-    };
-
-    private static string Publish(
-        string projectName,
-        string configuration = "Release",
-        string? output = null,
-        bool selfContained = false,
-        bool singleFile = false,
-        bool readyToRun = false,
-        bool useAppHost = true,
-        TrimLevel trimLevel = TrimLevel.None,
-        string? runId = null)
-    {
-        var args = new List<string>
-        {
-            "--runtime", RuntimeInformation.RuntimeIdentifier,
-            selfContained || trimLevel != TrimLevel.None ? "--self-contained" : "--no-self-contained",
-            $"/p:PublishTrimmed={(trimLevel == TrimLevel.None ? "false" : "")}",
-            $"/p:PublishSingleFile={(singleFile ? "true" : "")}",
-            $"/p:PublishReadyToRun={(readyToRun ? "true" : "")}",
-            "/p:PublishAot=false"
-        };
-
-        if (trimLevel != TrimLevel.None)
-        {
-            // /p:TrimLevel=
-            args.Add(GetTrimLevelProperty(trimLevel));
-        }
-
-        if (!useAppHost)
-        {
-            args.Add("/p:UseAppHost=false");
-        }
-
-        return PublishImpl(projectName, configuration, output, args, runId);
-    }
-
-    private static string PublishAot(
-        string projectName,
-        string configuration = "Release",
-        string? output = null,
-        TrimLevel trimLevel = TrimLevel.Default,
-        string? runId = null)
-    {
-        var args = new List<string>
-        {
-            "--runtime", RuntimeInformation.RuntimeIdentifier,
-            "--self-contained",
-            "/p:PublishSingleFile=",
-            "/p:PublishAot=true",
-            $"/p:PublishTrimmed={(trimLevel == TrimLevel.None ? "false" : "")}",
-        };
-
-        if (trimLevel != TrimLevel.None)
-        {
-            // /p:TrimLevel=
-            args.Add(GetTrimLevelProperty(trimLevel));
-        }
-
-        return PublishImpl(projectName, configuration, output, args, runId);
-    }
-
-    private static string PublishImpl(string projectName, string configuration = "Release", string? output = null, IEnumerable<string>? args = null, string? runId = null)
-    {
-        ArgumentNullException.ThrowIfNullOrEmpty(projectName);
-
-        var projectPath = Path.Combine(PathHelper.ProjectsDir, projectName, projectName + ".csproj");
-
-        if (!File.Exists(projectPath))
-        {
-            throw new ArgumentException($"Project at '{projectPath}' could not be found", nameof(projectName));
-        }
-
-        runId ??= Random.Shared.NextInt64().ToString();
-        output ??= Path.Combine(PathHelper.BenchmarkArtifactsDir, projectName, runId);
-
-        var cmdArgs = new List<string>
-        {
-            projectPath,
-            $"--configuration", configuration
-        };
-
-        DotNetCli.Clean(cmdArgs);
-
-        cmdArgs.AddRange(new[] { $"--output", output });
-        cmdArgs.Add("--disable-build-servers");
-        if (args is not null)
-        {
-            cmdArgs.AddRange(args);
-        }
-
-        DotNetCli.Publish(cmdArgs);
-
-        var appExePath = Path.Join(output, projectName);
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            appExePath += ".exe";
-        }
-
-        if (!File.Exists(appExePath))
-        {
-            var appDllPath = Path.Join(output, projectName + ".dll");
-            return !File.Exists(appDllPath) ? throw new InvalidOperationException($"Could not find application exe or dll '{appDllPath}'") : appDllPath;
-        }
-
-        return appExePath;
-    }
-
-    private static string GetTrimLevelProperty(TrimLevel trimLevel)
-    {
-        return "/p:TrimMode=" + trimLevel switch
-        {
-            TrimLevel.Default => "",
-            _ => Enum.GetName(trimLevel)?.ToLower() ?? ""
-        };
-    }
-
-    private static TrimLevel GetTrimLevel(string projectName)
-    {
-        if (projectName.Contains("EfCore", StringComparison.OrdinalIgnoreCase)
-            || projectName.Contains("Dapper", StringComparison.OrdinalIgnoreCase))
-        {
-            return TrimLevel.Partial;
-        }
-
-        if (projectName.Contains("Console"))
-        {
-            return TrimLevel.Default;
-        }
-
-        if (projectName.Contains("HelloWorld"))
-        {
-            return TrimLevel.Full;
-        }
-
-        return TrimLevel.Default;
-    }
-}
-
-class AppRunner
-{
-    private static readonly string _dotnetFileName = "dotnet" + (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "");
-
-    public static void Run(string appExePath, params (string, string)[] envVars)
-    {
-        if (!File.Exists(appExePath))
-        {
-            throw new ArgumentException($"Could not find application exe '{appExePath}'", nameof(appExePath));
-        }
-
-        var isAppHost = !Path.GetExtension(appExePath)!.Equals(".dll", StringComparison.OrdinalIgnoreCase);
-
-        var process = new Process
-        {
-            StartInfo =
-            {
-                FileName = isAppHost ? appExePath : _dotnetFileName,
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true
-            }
-        };
-
-        if (!isAppHost)
-        {
-            process.StartInfo.ArgumentList.Add(appExePath);
-        }
-
-        foreach (var (name, value) in envVars)
-        {
-            process.StartInfo.Environment.Add(name, value);
-        }
-
-        if (!process.Start())
-        {
-            HandleError(process, "Failed to start application process");
-        }
-
-        process.WaitForExit();
-
-        if (process.ExitCode != 0)
-        {
-            HandleError(process, $"Application process failed on exit ({process.ExitCode})");
-        }
-
-        static void HandleError(Process process, string message)
-        {
-            var output = process.StandardOutput.ReadToEnd();
-            var error = process.StandardError.ReadToEnd();
-
-            var sb = new StringBuilder();
-            sb.AppendLine(message);
-            sb.AppendLine("Standard output:");
-            sb.AppendLine(output);
-            sb.AppendLine("Standard error:");
-            sb.AppendLine(error);
-
-            throw new InvalidOperationException(sb.ToString());
-        }
-    }
-}
-
-
-class DotNetCli
-{
-    private static readonly string _fileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
-    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
-
-    public static void Clean(IEnumerable<string> args)
-    {
-        RunCommand("clean", args);
-    }
-
-    public static void Publish(IEnumerable<string> args)
-    {
-        RunCommand("publish", args);
-    }
-
-    private static void RunCommand(string commandName, IEnumerable<string> args)
-    {
-        var process = new Process
-        {
-            StartInfo =
-            {
-                FileName = _fileName,
-                UseShellExecute = false
-            }
-        };
-
-        process.StartInfo.ArgumentList.Add(commandName);
-        foreach (var arg in args)
-        {
-            process.StartInfo.ArgumentList.Add(arg);
-        }
-
-        var cmdLine = $"{process.StartInfo.FileName} {string.Join(' ', process.StartInfo.ArgumentList)}";
-        Console.WriteLine("Running dotnet CLI with cmd line:");
-        Console.WriteLine(cmdLine);
-        Console.WriteLine();
-
-        if (!process.Start())
-        {
-            throw new InvalidOperationException($"dotnet {commandName} failed");
-        }
-
-        process.WaitForExit();
-
-        if (!process.WaitForExit(_timeout))
-        {
-            process.Kill();
-
-            throw new InvalidOperationException($"dotnet {commandName} took longer than the allowed time of {_timeout}");
-        }
-
-        if (process.ExitCode != 0)
-        {
-            throw new InvalidOperationException($"dotnet {commandName} failed on exit ({process.ExitCode})");
-        }
-    }
-}
-
-class PathHelper
-{
-    public static string RepoRoot { get; } = GetRepoRoot();
-    public static string ProjectsDir { get; } = Path.Combine(RepoRoot, "src");
-    public static string ArtifactsDir { get; } = Path.Combine(RepoRoot, ".artifacts");
-    public static string BenchmarkArtifactsDir { get; } = Path.Combine(ArtifactsDir, "benchmarks");
-
-    private static string GetRepoRoot()
-    {
-        var currentDir = new DirectoryInfo(Directory.GetCurrentDirectory());
-        DirectoryInfo? repoDir = null;
-
-        while (true)
-        {
-            if (currentDir is null)
-            {
-                // We hit the file system root
-                break;
-            }
-
-            if (File.Exists(Path.Join(currentDir.FullName, "TrimmedTodo.sln")))
-            {
-                // We're in the repo root
-                repoDir = currentDir;
-                break;
-            }
-
-            currentDir = currentDir.Parent;
-        }
-
-        return repoDir is null ? throw new InvalidOperationException("Couldn't find repo directory") : repoDir.FullName;
-    }
-}
-
-enum TrimLevel
-{
-    None,
-    Default,
-    Partial,
-    Full
 }

--- a/tests/Benchmarks/Program.cs
+++ b/tests/Benchmarks/Program.cs
@@ -408,9 +408,13 @@ class DotNetCli
             }
         };
 
-        process.StartInfo.Arguments = $"{commandName} {string.Join(' ', args.Select(a => a.Contains(' ') ? $"\"{a}\"" : a))}";
+        process.StartInfo.ArgumentList.Add(commandName);
+        foreach (var arg in args)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
 
-        var cmdLine = $"{process.StartInfo.FileName} {process.StartInfo.Arguments}";
+        var cmdLine = $"{process.StartInfo.FileName} {string.Join(' ', process.StartInfo.ArgumentList)}";
         Console.WriteLine("Running dotnet CLI with cmd line:");
         Console.WriteLine(cmdLine);
         Console.WriteLine();

--- a/tests/Benchmarks/ProjectBuilder.cs
+++ b/tests/Benchmarks/ProjectBuilder.cs
@@ -1,0 +1,181 @@
+using System.Runtime.InteropServices;
+using System.Xml.Linq;
+
+namespace Benchmarks;
+
+class ProjectBuilder
+{
+    public static PublishResult Publish(string projectName, PublishScenario scenario) => scenario switch
+    {
+        PublishScenario.Default => Publish(projectName, runId: Enum.GetName(scenario)),
+        PublishScenario.NoAppHost => Publish(projectName, useAppHost: false, runId: Enum.GetName(scenario)),
+        PublishScenario.ReadyToRun => Publish(projectName, readyToRun: true, runId: Enum.GetName(scenario)),
+        PublishScenario.SelfContained => Publish(projectName, selfContained: true, trimLevel: TrimLevel.None, runId: Enum.GetName(scenario)),
+        PublishScenario.SelfContainedReadyToRun => Publish(projectName, selfContained: true, readyToRun: true, trimLevel: TrimLevel.None, runId: Enum.GetName(scenario)),
+        PublishScenario.SingleFile => Publish(projectName, selfContained: true, singleFile: true, trimLevel: TrimLevel.None, runId: Enum.GetName(scenario)),
+        PublishScenario.SingleFileReadyToRun => Publish(projectName, selfContained: true, singleFile: true, readyToRun: true, trimLevel: TrimLevel.None, runId: Enum.GetName(scenario)),
+        PublishScenario.Trimmed => Publish(projectName, selfContained: true, singleFile: true, trimLevel: GetTrimLevel(projectName), runId: Enum.GetName(scenario)),
+        PublishScenario.TrimmedReadyToRun => Publish(projectName, selfContained: true, singleFile: true, readyToRun: true, trimLevel: GetTrimLevel(projectName), runId: Enum.GetName(scenario)),
+        PublishScenario.AOT => PublishAot(projectName, trimLevel: GetTrimLevel(projectName), runId: Enum.GetName(scenario)),
+        _ => throw new ArgumentException("Unrecognized publish scenario", nameof(scenario))
+    };
+
+    private static PublishResult Publish(
+        string projectName,
+        string configuration = "Release",
+        string? output = null,
+        bool selfContained = false,
+        bool singleFile = false,
+        bool readyToRun = false,
+        bool useAppHost = true,
+        TrimLevel trimLevel = TrimLevel.None,
+        string? runId = null)
+    {
+        var args = new List<string>
+        {
+            "--runtime", RuntimeInformation.RuntimeIdentifier,
+            selfContained || trimLevel != TrimLevel.None ? "--self-contained" : "--no-self-contained",
+            $"/p:PublishTrimmed={(trimLevel == TrimLevel.None ? "false" : "")}",
+            $"/p:PublishSingleFile={(singleFile ? "true" : "")}",
+            $"/p:PublishReadyToRun={(readyToRun ? "true" : "")}",
+            "/p:PublishAot=false"
+        };
+
+        if (trimLevel != TrimLevel.None)
+        {
+            args.Add($"/p:TrimMode={GetTrimLevelPropertyValue(trimLevel)}");
+        }
+
+        if (!useAppHost)
+        {
+            args.Add("/p:UseAppHost=false");
+        }
+
+        return PublishImpl(projectName, configuration, output, args, runId);
+    }
+
+    private static PublishResult PublishAot(
+        string projectName,
+        string configuration = "Release",
+        string? output = null,
+        TrimLevel trimLevel = TrimLevel.Default,
+        string? runId = null)
+    {
+        if (trimLevel == TrimLevel.None)
+        {
+            throw new ArgumentOutOfRangeException(nameof(trimLevel), "'TrimLevel.None' is not supported when publishing for AOT.");
+        }
+
+        var args = new List<string>
+        {
+            "--runtime", RuntimeInformation.RuntimeIdentifier,
+            "--self-contained",
+            "/p:PublishAot=true",
+            "/p:PublishSingleFile=",
+            "/p:PublishTrimmed="
+        };
+
+        if (trimLevel != TrimLevel.None)
+        {
+            args.Add($"/p:TrimMode={GetTrimLevelPropertyValue(trimLevel)}");
+        }
+
+        return PublishImpl(projectName, configuration, output, args, runId);
+    }
+
+    private static PublishResult PublishImpl(string projectName, string configuration = "Release", string? output = null, IEnumerable<string>? args = null, string? runId = null)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(projectName);
+
+        var projectPath = Path.Combine(PathHelper.ProjectsDir, projectName, projectName + ".csproj");
+
+        if (!File.Exists(projectPath))
+        {
+            throw new ArgumentException($"Project at '{projectPath}' could not be found", nameof(projectName));
+        }
+
+        runId ??= Random.Shared.NextInt64().ToString();
+        output ??= Path.Combine(PathHelper.BenchmarkArtifactsDir, projectName, runId);
+
+        var cmdArgs = new List<string>
+        {
+            projectPath,
+            $"--configuration", configuration
+        };
+
+        DotNetCli.Clean(cmdArgs);
+
+        cmdArgs.AddRange(new[] { $"--output", output });
+        cmdArgs.Add("--disable-build-servers");
+        if (args is not null)
+        {
+            cmdArgs.AddRange(args);
+        }
+
+        DotNetCli.Publish(cmdArgs);
+
+        var appFilePath = Path.Join(output, projectName);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            appFilePath += ".exe";
+        }
+
+        if (!File.Exists(appFilePath))
+        {
+            appFilePath = Path.Join(output, projectName + ".dll");
+            if (!File.Exists(appFilePath))
+            {
+                throw new InvalidOperationException($"Could not find application exe or dll '{appFilePath}'");
+            }
+        }
+
+        return new(appFilePath, GetUserSecretsId(projectPath));
+    }
+
+    private static string? GetUserSecretsId(string projectFilePath)
+    {
+        var xml = XDocument.Load(projectFilePath);
+        var userSecretsIdElement = xml.Descendants("UserSecretsId").FirstOrDefault();
+        return userSecretsIdElement?.Value;
+    }
+
+    private static string GetTrimLevelPropertyValue(TrimLevel trimLevel)
+    {
+        return trimLevel switch
+        {
+            TrimLevel.Default => "",
+            _ => Enum.GetName(trimLevel)?.ToLower() ?? ""
+        };
+    }
+
+    private static TrimLevel GetTrimLevel(string projectName)
+    {
+        if (projectName.Contains("EfCore", StringComparison.OrdinalIgnoreCase)
+            || projectName.Contains("Dapper", StringComparison.OrdinalIgnoreCase))
+        {
+            return TrimLevel.Partial;
+        }
+
+        if (projectName.Contains("Console"))
+        {
+            return TrimLevel.Default;
+        }
+
+        if (projectName.Contains("HelloWorld"))
+        {
+            return TrimLevel.Full;
+        }
+
+        return TrimLevel.Default;
+    }
+}
+
+public record PublishResult(string AppFilePath, string? UserSecretsId = null);
+
+enum TrimLevel
+{
+    None,
+    Default,
+    Partial,
+    Full
+}

--- a/tests/Benchmarks/RatioColumn.cs
+++ b/tests/Benchmarks/RatioColumn.cs
@@ -1,0 +1,67 @@
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+
+namespace Benchmarks;
+
+public class RatioColumn : IColumn
+{
+    public string Id { get; } = "Ratio";
+    public string ColumnName { get; } = "Ratio";
+    public bool AlwaysShow { get; } = false;
+    public ColumnCategory Category { get; } = ColumnCategory.Custom;
+    public int PriorityInCategory { get; } = 0;
+    public bool IsNumeric { get; } = true;
+    public UnitType UnitType { get; } = UnitType.Dimensionless;
+    public string Legend { get; } = "[CurrentScenario]/[Default]";
+
+    public string GetValue(Summary summary, BenchmarkCase benchmarkCase)
+    {
+        var baseline = summary.BenchmarksCases
+            .SingleOrDefault(c =>
+            {
+                var scenario = c.Parameters[nameof(StartupTimeBenchmarks.Scenario)];
+
+                if (scenario is not PublishScenario.Default)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < benchmarkCase.Parameters.Count; i++)
+                {
+                    var p = benchmarkCase.Parameters[i];
+
+                    // Skip scenario parameter
+                    if (p.Name == nameof(StartupTimeBenchmarks.Scenario)) continue;
+
+                    if (c.Parameters[p.Name] != p.Value)
+                    {
+                        // Parameter doesn't match
+                        return false;
+                    }
+                }
+                return true;
+            });
+
+        if (baseline is not null)
+        {
+            var baselineReport = summary.Reports.First(r => r.BenchmarkCase == baseline);
+            var report = summary.Reports.First(r => r.BenchmarkCase == benchmarkCase);
+
+            return (report.ResultStatistics.Mean / baselineReport.ResultStatistics.Mean).ToString("#.00");
+        }
+
+        return "?";
+    }
+
+    public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style) => GetValue(summary, benchmarkCase);
+
+    public bool IsAvailable(Summary summary) =>
+        summary.BenchmarksCases.Where(c => c.Parameters[nameof(StartupTimeBenchmarks.Scenario)] switch
+        {
+            PublishScenario.Default => true,
+            _ => false
+        }).Any();
+
+    public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
+}


### PR DESCRIPTION
Uses BenchmarkDotNet and a bunch of changes to measure startup time impact of various publish options.

This also fixes a bunch of issues caused by changes to the JWT Bearer AuthN stuff in rc.1

E.g.
|                          ProjectName |             Scenario |     Mean |     Error |   StdDev | Ratio |
|------------------------------------- |--------------------- |---------:|----------:|---------:|------:|
| TrimmedTodo.MinimalApi.Dapper.Sqlite |              Default | 364.8 ms |  32.98 ms | 21.82 ms |  1.00 |
| TrimmedTodo.MinimalApi.Dapper.Sqlite | SingleFileReadyToRun | 301.7 ms |  96.16 ms | 63.60 ms |   .83 |
|                                      |                      |          |           |          |       |
| TrimmedTodo.MinimalApi.EfCore.Sqlite |              Default | 713.9 ms |  65.37 ms | 43.24 ms |  1.00 |
| TrimmedTodo.MinimalApi.EfCore.Sqlite | SingleFileReadyToRun | 456.0 ms | 101.23 ms | 66.96 ms |   .64 |