### PR TITLE
Use connections from NpgsqlDataSourceBuilder

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.2" />
-    <PackageVersion Include="Npgsql" Version="8.0.0-preview.1" />
+    <PackageVersion Include="Npgsql" Version="8.0.0-preview.2" />
   </ItemGroup>
 </Project>

--- a/src/TrimmedTodo.MinimalApi.PostgreSQL/Program.cs
+++ b/src/TrimmedTodo.MinimalApi.PostgreSQL/Program.cs
@@ -16,11 +16,15 @@ var builder = WebApplication.CreateBuilder(args);
 var connectionString = builder.Configuration.GetConnectionString("TodoDb")
     ?? builder.Configuration["CONNECTION_STRING"]
     ?? "Server=localhost;Port=5432;User Id=TodosApp;Password=password;Database=Todos";
-builder.Services.AddScoped(_ =>
+builder.Services.AddSingleton(_ =>
 {
-    var db = new NpgsqlConnection(connectionString);
-    db.Open();
-    return db;
+    var dataSourceBuilder = new NpgsqlSlimDataSourceBuilder(connectionString);
+    return dataSourceBuilder.Build();
+});
+builder.Services.AddScoped(serviceProvider =>
+{
+    var dataSource = serviceProvider.GetRequiredService<NpgsqlDataSource>();
+    return dataSource.OpenConnection();
 });
 
 //builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
This changes Npgsql usage to get connection from a "slim" data source; this has various stuff not opted into by default, and should both reduce the number of trim/AOT warnings and size. /cc @DamianEdwards @eerhardt

Note that Npgsql 8.0.0-preview.2 will be out this evening; switching to that should bring a substantial size reduction over 8.0.0-preview.1 (and we're still at it).

BTW @DamianEdwards there's various modernizations/improvements possible there, like full data source usage (no need to deal with connections), positional parameters... But that would require changes to your glorious ORM layer...

Note that I could actually run TrimmedTodo.MinimalApi.PostgreSQL because:

```
/home/roji/projects/TrimmedTodo/src/TrimmedTodo.MinimalApi.PostgreSQL/Microsoft.AspNetCore.Http.Generators/Microsoft.AspNetCore.Http.Generators.RequestDelegateGenerator/GeneratedRouteBuilderExtensions.g.cs(735,30): error CS0128: A local variable or function named 'isSuccessful' is 
already defined in this scope [/home/roji/projects/TrimmedTodo/src/TrimmedTodo.MinimalApi.PostgreSQL/TrimmedTodo.MinimalApi.PostgreSQL.csproj]
/home/roji/projects/TrimmedTodo/src/TrimmedTodo.MinimalApi.PostgreSQL/Microsoft.AspNetCore.Http.Generators/Microsoft.AspNetCore.Http.Generators.RequestDelegateGenerator/GeneratedRouteBuilderExtensions.g.cs(761,30): error CS0128: A local variable or function named 'isSuccessful' is 
already defined in this scope [/home/roji/projects/TrimmedTodo/src/TrimmedTodo.MinimalApi.PostgreSQL/TrimmedTodo.MinimalApi.PostgreSQL.csproj]
/home/roji/projects/TrimmedTodo/src/TrimmedTodo.MinimalApi.PostgreSQL/Microsoft.AspNetCore.Http.Generators/Microsoft.AspNetCore.Http.Generators.RequestDelegateGenerator/GeneratedRouteBuilderExtensions.g.cs(829,30): error CS0128: A local variable or function named 'isSuccessful' is 
already defined in this scope [/home/roji/projects/TrimmedTodo/src/TrimmedTodo.MinimalApi.PostgreSQL/TrimmedTodo.MinimalApi.PostgreSQL.csproj]
/home/roji/projects/TrimmedTodo/src/TrimmedTodo.MinimalApi.PostgreSQL/Microsoft.AspNetCore.Http.Generators/Microsoft.AspNetCore.Http.Generators.RequestDelegateGenerator/GeneratedRouteBuilderExtensions.g.cs(867,30): error CS0128: A local variable or function named 'isSuccessful' is 
already defined in this scope [/home/roji/projects/TrimmedTodo/src/TrimmedTodo.MinimalApi.PostgreSQL/TrimmedTodo.MinimalApi.PostgreSQL.csproj]
```